### PR TITLE
Add support for import/export of cvs mainline

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ same time, the results are undefined.
 
 Bigitr imports branches from CVS into special import branches (with
 names starting with "cvs-") in Git.  It also exports branches in
-Git into branches in CVS.  It will not touch the CVS trunk (at
-least at this time).
+Git into branches in CVS.
 
 Note: It will not synchronize only parts of a CVS `sub/module`.  It is
 all or nothing: for any particular `sub/module`, any files not in
@@ -343,6 +342,11 @@ sections in that file.
     posthook.imp.git.<branch> = <command> <args> # hook to run in Git clone after committing to Git branch <branch> from CVS
     posthook.exp.git.<branch> = <command> <args> # hook to run in Git clone after committing to CVS from Git branch <branch>
     posthook.cvs.<branch> = <command> <args> # hook to run in CVS checkout after committing to CVS branch <branch>
+
+`<branch>` may refer to either a "real" branch name, or a symbolic
+branch. Symbolic branches are used to configure branches that cannot
+be referenced directly. Currently, the only symbolic branch supported
+by bigitr is `@{trunk}`, which is used to refer to the CVS trunk.
 
 The `gitroot`, `cvsroot`, `email`, `skeleton` keys, and general
 (non-branch-specific) hooks, may be in the `GLOBAL` section. Entries


### PR DESCRIPTION
CVS treats the mainline branch as a special case, insofar as the
commands to work with it do not support using the '-r' flag. This change
adds special handling for symbolic branches, using @{branch name}. For
the mainline branch in CVS, we use @{trunk}. This enables repository map
configurations like:

```
cvs.@{trunk} = master
git.master = @{trunk}
```

Replaces #12 and #17
Fixes #11
